### PR TITLE
last-push-before-shifting-to-clist-api

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -13,8 +13,8 @@
     <color name="atcoderColor">#000000</color>
     <color name="titleColor">#ffffff</color>
     <color name="subtitleColor">#80ffffff</color>
-    <color name="trackColor">#7f302b</color>
-    <color name="indicatorColor">@color/primaryDarkColor</color>
+    <color name="trackColor">@color/primaryLightColor</color>
+    <color name="indicatorColor">@color/primaryColor</color>
     <color name="unknownColor">@color/primaryLightColor</color>
     <color name="splashColor">#000000</color>
 </resources>


### PR DESCRIPTION
Since the retrieving codechef contests by simply parsing the HTML code of their contests page was no longer an option. Shifting to a 3rd party API was the best option